### PR TITLE
ci: impedir publicación de artículos en borrador

### DIFF
--- a/.github/workflows/revisar.yml
+++ b/.github/workflows/revisar.yml
@@ -35,6 +35,20 @@ jobs:
             content/**.md
             content/**/**.md
 
+      - name: Revisar que artículos no estén en borrador
+        if: steps.archivos-md-modificados.outputs.any_changed == 'true'
+        env:
+          ARCHIVOS_MD_CAMBIADOS: ${{ steps.archivos-md-modificados.outputs.all_changed_files }}
+        run: |
+          error=0
+          for archivo in ${ARCHIVOS_MD_CAMBIADOS}; do
+            if awk '/^\+\+\+$/{f=1; next} /^\+\+\+$/{f=0} f && /^draft\s*=\s*true/' "$archivo" | grep -q .; then
+              echo "::error file=${archivo}::El artículo tiene 'draft = true', no debe estar en borrador"
+              error=1
+            fi
+          done
+          exit $error
+
       - name: Revisar formato markdown
         if: steps.archivos-md-modificados.outputs.any_changed == 'true'
         env:


### PR DESCRIPTION
Se añade un paso en el flujo de revisión (revisar.yml) que verifica que ningún artículo modificado tenga draft = true en su frontmatter TOML. Si lo encuentra, falla la CI.

Si un artículo se publica como draft y luego se cambia a no-borrador, ya no es posible anunciarlo en Mastodon porque el anuncio se hace al momento de la publicación inicial. Al bloquear la publicación de drafts, aseguramos que solo artículos listos para anunciarse lleguen a main.

Se usa la salida all_changed_files del action tj-actions/changed-files y un script con awk que busca draft = true dentro de los delimitadores +++ del frontmatter TOML de cada archivo. Los errores se reportan con el formato ::error de GitHub Actions para que aparezcan como anotaciones en el PR.