### PR TITLE
artículo: GUADEC 2026, GNOME se reúne en A Coruña

### DIFF
--- a/content/20260716142429268.md
+++ b/content/20260716142429268.md
@@ -1,0 +1,105 @@
++++
+title = "GUADEC 2026: GNOME se reúne en A Coruña"
+slug = "20260716142429268"
+date = "2026-07-16T14:24:42.963496+02:00"
+[taxonomies]
+autor = ["Víctor Manuel Jáquez Leal"]
+tema = ["noticias"]
++++
+
+En 1997, un grupo de estudiantes mexicanos encabezados por Miguel de Icaza
+anunciaron el proyecto [GNOME](https://es.wikipedia.org/wiki/GNOME): un entorno
+de escritorio completamente libre para sistemas [tipo
+Unix](https://es.wikipedia.org/wiki/Unix-like). Casi tres décadas después, aquel
+proyecto universitario se ha convertido en uno de los pilares del software
+libre, y cada año su comunidad se reúne en GUADEC, la conferencia internacional
+más importante del ecosistema. Este 2026, la cita es en A Coruña, Galicia, del
+16 al 21 de julio.
+
+## ¿Qué es GNOME?
+
+GNOME es un entorno de escritorio [libre y de código
+abierto](https://es.wikipedia.org/wiki/Software_libre_y_de_c%C3%B3digo_abierto)
+diseñado para sistemas operativos basados en Linux y otros Unix. Es el
+escritorio predeterminado de distribuciones como
+[Fedora](https://es.wikipedia.org/wiki/Fedora_(distribuci%C3%B3n_Linux)),
+[Ubuntu](https://es.wikipedia.org/wiki/Ubuntu),
+[Debian](https://es.wikipedia.org/wiki/Debian) y [Red Hat Enterprise
+Linux](https://es.wikipedia.org/wiki/Red_Hat_Enterprise_Linux). Su interfaz se
+caracteriza por la simplicidad, la usabilidad y un enfoque minimalista que
+prioriza la concentración de quien lo usa.
+
+Pero GNOME es mucho más que un escritorio. El proyecto produce decenas de
+aplicaciones (`Nautilus`, `GNOME Builder`, `GNOME Web`, `GNOME Maps`, `GNOME
+Calendar`, por nombrar algunas), bibliotecas (`GTK`, `GLib`, `GSK`, `GStreamer`)
+y servicios de infraestructura (`Flatpak`, `GNOME OS`). Detrás de todo ello hay
+una [fundación sin fines de
+lucro](https://es.wikipedia.org/wiki/Fundaci%C3%B3n_GNOME) que coordina
+esfuerzos, gestiona financiamiento y organiza eventos, y una comunidad global de
+personas voluntarias y profesionales que contribuyen código, diseño,
+documentación, traducción y soporte.
+
+## GUADEC: la conferencia de la comunidad
+
+GUADEC, acrónimo de *GNOME Users And Developers European Conference*, nació en
+2000 como un encuentro presencial de la comunidad europea. Con los años se ha
+convertido en la conferencia más relevante del ecosistema GNOME a nivel mundial,
+atrayendo a cientos de personas usuarias, desarrolladoras, diseñadoras y
+entusiastas. Es un evento híbrido: se puede asistir de forma presencial o seguir
+las transmisiones en vivo desde cualquier parte del mundo.
+
+La edición 2026 tiene lugar en A Coruña, una ciudad costera de Galicia, al
+noroeste de España, rodeada por el Atlántico. Entre sus atractivos destaca la
+[Torre de Hércules](https://es.wikipedia.org/wiki/Torre_de_H%C3%A9rcules), el
+faro más antiguo del mundo en funcionamiento, declarado [Patrimonio de la
+Humanidad](https://es.wikipedia.org/wiki/Patrimonio_de_la_Humanidad) por la
+[UNESCO](https://es.wikipedia.org/wiki/Unesco) en 2009.
+
+## El programa
+
+La conferencia se estructura en tres bloques:
+
+- **16, 17 y 18 de julio**: días de ponencias. Se presentan dos pistas
+  simultáneas con charlas técnicas, comunitarias y de diseño.
+- **19 y 20 de julio**: [BoFs](https://es.wikipedia.org/wiki/Birds_of_a_Feather)
+  (*Birds of a Feather*) y talleres. Sesiones de trabajo colaborativo donde se
+  discuten y planifican temas concretos del proyecto.
+- **21 de julio**: día de exploración libre, autoorganizado por quienes asisten.
+
+Entre las ponencias destacan temas como `Remote GNOME`, sobre el impacto de la
+transición de `X11` a `Wayland` en el acceso remoto al escritorio, y `Towards a
+Local-First Desktop`, sobre la construcción de aplicaciones GNOME con
+sincronización entre pares sin depender de la nube. El programa completo puede
+consultarse en
+[events.gnome.org](https://events.gnome.org/event/306/timetable/).
+
+## Cómo seguirla en vivo
+
+Todas las ponencias se transmiten en directo a través del canal oficial de GNOME
+en `YouTube`. Los *streams* se organizan por día y por pista:
+
+- Canal de `YouTube` de GNOME:
+  [youtube.com/@GNOMEDesktop](https://www.youtube.com/@GNOMEDesktop)
+- Transmisiones en vivo:
+  [youtube.com/@GNOMEDesktop/streams](https://www.youtube.com/@GNOMEDesktop/streams)
+
+Las grabaciones quedan disponibles en el mismo canal una vez concluye cada
+jornada, por lo que es posible verlas en diferido si la zona horaria no
+acompaña.
+
+## Más allá de las charlas
+
+GUADEC no es solo una sucesión de ponencias. Es también el espacio donde se
+toman decisiones sobre el futuro del proyecto, donde quienes contribuyen desde
+rincones remotos del planeta se encuentran cara a cara, y donde personas que
+están empezando a involucrarse encuentran mentoría y orientación. El evento se
+rige por un [código de conducta](https://conduct.gnome.org/) que garantiza un
+entorno seguro y respetuoso para todas las personas participantes.
+
+## Referencias
+
+1. [Sitio oficial de GUADEC 2026](https://events.gnome.org/event/306/)
+2. [GNOME en Wikipedia](https://es.wikipedia.org/wiki/GNOME)
+3. [Fundación GNOME](https://foundation.gnome.org/)
+4. [La ciudad de A Coruña (página oficial de GUADEC)](https://events.gnome.org/event/306/page/771-the-city)
+5. [Canal de YouTube de GNOME](https://www.youtube.com/@GNOMEDesktop)

--- a/es-local.dic
+++ b/es-local.dic
@@ -1,4 +1,4 @@
-personal_ws-1.1 es 3444 utf-8
+personal_ws-1.1 es 3452 utf-8
 aaron
 abelson
 abimelec
@@ -190,6 +190,7 @@ autodescriptivo
 autofs
 automounting
 automágicamente
+autoorganizado
 autotools
 auxiliarme
 avaaz
@@ -278,6 +279,7 @@ biography
 bioinformatics
 bioinformática
 bios
+birds
 bison
 bitcoin
 bitcoins
@@ -306,6 +308,7 @@ bluez
 blurb
 blvd
 bocanegra
+bofs
 bogomips
 boltzmann
 bond
@@ -1013,6 +1016,7 @@ farías
 fast
 fault
 fbi
+feather
 featherstone
 febb
 february
@@ -1151,6 +1155,7 @@ gadget
 gadgets
 gaim
 galeon
+galicia
 game
 gamergate
 gamers
@@ -1940,6 +1945,7 @@ membresía
 memes
 memory
 mendoza
+mentoría
 mepis
 merde
 merequetengue
@@ -2919,6 +2925,7 @@ strange
 stream
 streamer
 streaming
+streams
 street
 string
 struct
@@ -3152,6 +3159,7 @@ ultimateman
 uml
 unam
 underground
+unesco
 unetea
 unfair
 unicorn


### PR DESCRIPTION
Describe qué es GNOME, su comunidad y la conferencia GUADEC 2026 celebrada en A Coruña, Galicia. Incluye el programa del evento, vínculos a las transmisiones en vivo por YouTube y referencias verificables.